### PR TITLE
[POA-727] Add new time keyed map

### DIFF
--- a/maps/time_key_map.go
+++ b/maps/time_key_map.go
@@ -39,21 +39,23 @@ func (m TimeMap[V]) Upsert(k time.Time, v V, onConflict func(v, newV V) V) {
 // If the key k is not already in the map, then it is entered into the map with
 // the value v.
 func (m TimeMap[V]) PutIfAbsent(k time.Time, v V) {
-	m.GetOrValue(k, v)
+	key := getInternalMapKey(k)
+	m.internalMap.PutIfAbsent(key, v)
 }
 
 // If the key k is not already in the map, then it is entered into the map with
 // the result of calling the supplied function. If the function returns an
 // error, then the map is not modified, and the error is returned.
 func (m TimeMap[V]) ComputeIfAbsent(k time.Time, computeValue func() (V, error)) error {
-	_, err := m.GetOrCompute(k, computeValue)
-	return err
+	key := getInternalMapKey(k)
+	return m.internalMap.ComputeIfAbsent(key, computeValue)
 }
 
 // If the key k is not already in the map, then it is entered into the map with
 // the result of calling the supplied function.
 func (m TimeMap[V]) ComputeIfAbsentNoError(k time.Time, computeValue func() V) {
-	m.GetOrComputeNoError(k, computeValue)
+	key := getInternalMapKey(k)
+	m.internalMap.ComputeIfAbsentNoError(key, computeValue)
 }
 
 func (m TimeMap[V]) Add(other TimeMap[V], onConflict func(v, newV V) V) {

--- a/maps/time_key_map.go
+++ b/maps/time_key_map.go
@@ -1,0 +1,163 @@
+package maps
+
+import (
+	"time"
+
+	"github.com/akitasoftware/go-utils/sets"
+)
+
+func getInternalMapKey(t time.Time) int64 {
+	return t.Unix()
+}
+
+func getReverseKey(key int64) time.Time {
+	return time.Unix(key, 0)
+}
+
+type TimeMap[V any] struct {
+	internalMap map[int64]V
+}
+
+func NewTimeMap[V any]() TimeMap[V] {
+	return TimeMap[V]{
+		internalMap: make(map[int64]V),
+	}
+}
+
+func (tm TimeMap[V]) Put(k time.Time, v V) {
+	key := getInternalMapKey(k)
+	tm.internalMap[key] = v
+}
+
+func (m TimeMap[V]) Upsert(k time.Time, v V, onConflict func(v, newV V) V) {
+	newV := v
+	key := getInternalMapKey(k)
+	if oldV, exists := m.internalMap[key]; exists {
+		newV = onConflict(oldV, newV)
+	}
+	m.internalMap[key] = newV
+}
+
+// If the key k is not already in the map, then it is entered into the map with
+// the result of calling the supplied function. If the function returns an
+// error, then the map is not modified, and the error is returned.
+func (m TimeMap[V]) ComputeIfAbsent(k time.Time, computeValue func() (V, error)) error {
+	_, err := m.GetOrCompute(k, computeValue)
+	return err
+}
+
+// If the key k is not already in the map, then it is entered into the map with
+// the result of calling the supplied function.
+func (m TimeMap[V]) ComputeIfAbsentNoError(k time.Time, computeValue func() V) {
+	m.GetOrComputeNoError(k, computeValue)
+}
+
+func (m TimeMap[V]) Add(other TimeMap[V], onConflict func(v, newV V) V) {
+	for k, v := range other.internalMap {
+		timeKey := getReverseKey(k)
+		m.Upsert(timeKey, v, onConflict)
+	}
+}
+
+func (tm TimeMap[V]) Get(k time.Time) (V, bool) {
+	key := getInternalMapKey(k)
+	v, exists := tm.internalMap[key]
+	return v, exists
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the supplied function is called, and the resulting
+// value is entered into the map and returned.
+func (m TimeMap[V]) GetOrCompute(k time.Time, computeValue func() (V, error)) (V, error) {
+	key := getInternalMapKey(k)
+	if v, exists := m.internalMap[key]; exists {
+		return v, nil
+	}
+
+	v, err := computeValue()
+	if err != nil {
+		return v, err
+	}
+
+	m.internalMap[key] = v
+	return v, nil
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the supplied function is called, and the resulting
+// value is entered into the map and returned.
+func (m TimeMap[V]) GetOrComputeNoError(k time.Time, computeValue func() V) V {
+	key := getInternalMapKey(k)
+	if v, exists := m.internalMap[key]; exists {
+		return v
+	}
+
+	v := computeValue()
+	m.internalMap[key] = v
+	return v
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the default Go value is returned.
+func (m TimeMap[V]) GetOrDefault(k time.Time) V {
+	key := getInternalMapKey(k)
+	return m.internalMap[key]
+}
+
+// Returns the value associated with the given key k. If the key does not
+// already exist in the map, the supplied value is entered into the map and
+// returned.
+func (m TimeMap[V]) GetOrValue(k time.Time, value V) V {
+	key := getInternalMapKey(k)
+	v, exists := m.internalMap[key]
+	if !exists {
+		v = value
+		m.internalMap[key] = v
+	}
+	return v
+}
+
+func (m TimeMap[V]) ContainsKey(k time.Time) bool {
+	key := getInternalMapKey(k)
+	_, exists := m.internalMap[key]
+	return exists
+}
+
+func (m TimeMap[V]) Delete(k time.Time) {
+	key := getInternalMapKey(k)
+	delete(m.internalMap, key)
+}
+
+func (m TimeMap[V]) IsEmpty() bool {
+	return len(m.internalMap) == 0
+}
+
+func (m TimeMap[V]) Size() int {
+	return len(m.internalMap)
+}
+
+func (m TimeMap[V]) Keys() []time.Time {
+	keys := make([]time.Time, 0, len(m.internalMap))
+	for k := range m.internalMap {
+		timeKey := getReverseKey(k)
+		keys = append(keys, timeKey)
+	}
+	return keys
+}
+
+func (m TimeMap[V]) KeySet() sets.Set[time.Time] {
+	keys := sets.NewSet[time.Time]()
+	for k := range m.internalMap {
+		timeKey := getReverseKey(k)
+		keys.Insert(timeKey)
+	}
+	return keys
+}
+
+func (m TimeMap[V]) Values() []V {
+	values := make([]V, 0, len(m.internalMap))
+	for _, v := range m.internalMap {
+		values = append(values, v)
+	}
+	return values
+}

--- a/maps/time_key_map_test.go
+++ b/maps/time_key_map_test.go
@@ -16,7 +16,7 @@ func TestPutAndGet(t *testing.T) {
 	tm := NewTimeMap[int]()
 	now := time.Now()
 	tm.Put(now, 123)
-	val, exists := tm.Get(now)
+	val, exists := tm.Get(now).Get()
 	assert.True(t, exists)
 	assert.Equal(t, 123, val)
 }
@@ -28,7 +28,7 @@ func TestUpsert(t *testing.T) {
 	tm.Upsert(now, 2, func(oldVal, newVal int) int {
 		return oldVal + newVal
 	})
-	val, exists := tm.Get(now)
+	val, exists := tm.Get(now).Get()
 	assert.True(t, exists)
 	assert.Equal(t, 3, val)
 }
@@ -40,7 +40,7 @@ func TestComputeIfAbsent(t *testing.T) {
 		return 42, nil
 	})
 	assert.NoError(t, err)
-	val, exists := tm.Get(now)
+	val, exists := tm.Get(now).Get()
 	assert.True(t, exists)
 	assert.Equal(t, 42, val)
 }
@@ -51,7 +51,7 @@ func TestComputeIfAbsentNoError(t *testing.T) {
 	tm.ComputeIfAbsentNoError(now, func() int {
 		return 42
 	})
-	val, exists := tm.Get(now)
+	val, exists := tm.Get(now).Get()
 	assert.True(t, exists)
 	assert.Equal(t, 42, val)
 }
@@ -73,7 +73,7 @@ func TestDelete(t *testing.T) {
 	now := time.Now()
 	tm.Put(now, 123)
 	tm.Delete(now)
-	_, exists := tm.Get(now)
+	_, exists := tm.Get(now).Get()
 	assert.False(t, exists)
 }
 

--- a/maps/time_key_map_test.go
+++ b/maps/time_key_map_test.go
@@ -1,0 +1,112 @@
+package maps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTimeMap(t *testing.T) {
+	tm := NewTimeMap[int]()
+	assert.NotNil(t, tm)
+}
+
+func TestPutAndGet(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.Put(now, 123)
+	val, exists := tm.Get(now)
+	assert.True(t, exists)
+	assert.Equal(t, 123, val)
+}
+
+func TestUpsert(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.Put(now, 1)
+	tm.Upsert(now, 2, func(oldVal, newVal int) int {
+		return oldVal + newVal
+	})
+	val, exists := tm.Get(now)
+	assert.True(t, exists)
+	assert.Equal(t, 3, val)
+}
+
+func TestComputeIfAbsent(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	err := tm.ComputeIfAbsent(now, func() (int, error) {
+		return 42, nil
+	})
+	assert.NoError(t, err)
+	val, exists := tm.Get(now)
+	assert.True(t, exists)
+	assert.Equal(t, 42, val)
+}
+
+func TestComputeIfAbsentNoError(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.ComputeIfAbsentNoError(now, func() int {
+		return 42
+	})
+	val, exists := tm.Get(now)
+	assert.True(t, exists)
+	assert.Equal(t, 42, val)
+}
+
+func TestAdd(t *testing.T) {
+	tm1 := NewTimeMap[int]()
+	tm2 := NewTimeMap[int]()
+	now := time.Now()
+	tm1.Put(now, 1)
+	tm2.Put(now.Add(time.Hour), 2)
+	tm1.Add(tm2, func(v1, v2 int) int {
+		return v1 + v2
+	})
+	assert.Equal(t, 2, tm1.Size())
+}
+
+func TestDelete(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.Put(now, 123)
+	tm.Delete(now)
+	_, exists := tm.Get(now)
+	assert.False(t, exists)
+}
+
+func TestIsEmptyAndSize(t *testing.T) {
+	tm := NewTimeMap[int]()
+	assert.True(t, tm.IsEmpty())
+	assert.Equal(t, 0, tm.Size())
+	now := time.Now()
+	tm.Put(now, 123)
+	assert.False(t, tm.IsEmpty())
+	assert.Equal(t, 1, tm.Size())
+}
+
+func TestKeys(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.Put(now, 123)
+	keys := tm.Keys()
+	assert.Equal(t, 1, len(keys))
+}
+
+func TestValues(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	tm.Put(now, 123)
+	values := tm.Values()
+	assert.Contains(t, values, 123)
+}
+
+func TestContainsKey(t *testing.T) {
+	tm := NewTimeMap[int]()
+	now := time.Now()
+	assert.False(t, tm.ContainsKey(now))
+	tm.Put(now, 123)
+	assert.True(t, tm.ContainsKey(now))
+}


### PR DESCRIPTION
With this PR, we will add a new time-keyed map to our go utils. The map holds an internal map that has keys indexed on the UNIX values of the timestamp, and all the operations are done on this internal Map. 